### PR TITLE
Update docker-sslo-threathunting-clients.yaml

### DIFF
--- a/docker-sslo-threathunting-clients.yaml
+++ b/docker-sslo-threathunting-clients.yaml
@@ -96,7 +96,9 @@ services:
 
         # C2 server URL (you can modify this to the actual server you're targeting)
         C2_SERVER_URL = [
-            "https://c2.badguy.com/beacon"
+            "https://1c27eace-eb71-4548-8e0d-0c711ce2c699.cloudsecurity.ninja/beacon",
+            "https://60bc6420-c2ef-49f0-86e1-8cea63070032.cloudsecurity.ninja/beacon",
+            "https://716316b6-6836-4bb5-8cab-c5c94236952e.cloudsecurity.ninja/beacon" 
         ]
 
         # Payload to send


### PR DESCRIPTION
added multiple beaconing servers. Only one should point to 192.168.100.15 Ala the c2 server.